### PR TITLE
Bugfix/schema and timeout

### DIFF
--- a/tranql/api.py
+++ b/tranql/api.py
@@ -528,9 +528,19 @@ class SchemaGraph(StandardAPIResource):
                     application/json:
                         schema:
                           $ref: '#/definitions/Error'
+        parameters:
+            - in: query
+              name: force_update
+              schema:
+                type: boolean
+              required: false
+              default: false
+              description: Specifies if dynamic id lookup of curies will be performed
         """
+        force_update = request.args.get("force_update")
         tranql = TranQL (options={"registry": app.config.get('registry', False)})
-        schema = tranql.schema
+        schemafactory = tranql.schema_factory
+        schema = schemafactory.get_instance(force_update=force_update)
         schemaGraph = GraphTranslator(schema.schema_graph)
 
         # logger.info(schema.schema_graph.net.nodes)

--- a/tranql/main.py
+++ b/tranql/main.py
@@ -120,14 +120,14 @@ class TranQL:
         self.use_registry = options.get("registry", False) or self.config.get('USE_REGISTRY', False)
         # for testing singleton is causing problems
         self.recreate_schema = options.get('recreate_schema', False)
-        schema_factory = SchemaFactory(
+        self.schema_factory = SchemaFactory(
             backplane=backplane,
             use_registry=self.use_registry,
             update_interval=20*60,
             create_new=self.recreate_schema,
             tranql_config=self.config
         )
-        self.schema = schema_factory.get_instance()
+        self.schema = self.schema_factory.get_instance()
         self.parser = TranQLParser (self.schema)
 
     def parse (self, program):

--- a/tranql/requirements.txt
+++ b/tranql/requirements.txt
@@ -77,7 +77,7 @@ waitress==1.4.3
 wcwidth==0.1.7
 webencodings==0.5.1
 yarl==1.3.0
-PLATER-GRAPH==1.9.5
+PLATER-GRAPH==1.9.7
 git+git://github.com/patrickkwang/biolink-model-toolkit@master#egg=bmt
 git+https://github.com/ranking-agent/reasoner.git
 git+https://github.com/TranslatorSRI/reasoner-pydantic@v1.0.0#egg=reasoner-pydantic

--- a/tranql/tests/test_tranql.py
+++ b/tranql/tests/test_tranql.py
@@ -1901,7 +1901,7 @@ def test_redis_graph_cypher_options(GraphInterfaceMock):
             self.skip  = skip
             self.options_set = options_set
 
-        async def answer_trapi_question(self, message, options={}):
+        async def answer_trapi_question(self, message, options={}, timeout=0):
             assert message
             if self.options_set:
                 assert options
@@ -1945,3 +1945,144 @@ def test_redis_graph_cypher_options(GraphInterfaceMock):
             )
             select_statement = ast.statements[0]
             select_statement.execute(interpreter=tranql)
+
+
+# @patch("PLATER.services.util.graph_adapter.GraphInterface._GraphInterface")
+def test_redis_graph_query_redis_schema_empty_response():
+    """
+    Test for case where redis returns empty result. when the from clause is "/schema"
+
+    """
+    mock_schema_yaml = {
+        'schema':{
+            'redis': {
+                'doc': 'Red is a color but REDIS?',
+                'url': 'redis:',
+                'redis': True,
+                'redis_connection_params': {
+                    'host': 'local',
+                    'port': 6379
+                }
+            }
+        }
+    }
+
+    class graph_Inteface_mock:
+        def __init__(self, limit , skip, options_set):
+            self.limit = limit
+            self.skip  = skip
+            self.options_set = options_set
+
+        def get_schema(self, force_update=False):
+            return {
+                "biolink:Gene": {"biolink:Gene": {"related_to"}}
+            }
+
+        async def answer_trapi_question(self, message, options={}):
+            return {}
+    # we override the schema
+    with patch('PLATER.services.util.graph_adapter.GraphInterface.instance',
+               graph_Inteface_mock(limit=20, skip=100, options_set=True)):
+        tranql = TranQL()
+        with patch('yaml.safe_load', lambda x: copy.deepcopy(mock_schema_yaml)):
+            # clean up schema singleton
+            update_interval = 1
+            backplane = 'http://localhost:8099'
+            schema_factory = SchemaFactory(
+                backplane=backplane,
+                use_registry=False,
+                update_interval=update_interval,
+                create_new=True,
+                tranql_config={}
+            )
+            tranql.schema = schema_factory.get_instance()
+            ast = tranql.parse(
+                """
+                SELECT g1:gene->g2:gene
+                FROM '/schema'
+                where limit = 20 and skip = 100
+                """
+            )
+            select_statement = ast.statements[0]
+
+            select_statement.execute(interpreter=tranql)
+
+
+@patch("PLATER.services.util.graph_adapter.GraphInterface._GraphInterface")
+def test_query_timeout(GraphInterfaceMock):
+    """
+        Test for making sure that timeout is sent to graph interface answer_trapi method
+
+        """
+
+    mock_schema_yaml = {
+        'schema': {
+            'redis': {
+                'doc': 'Red is a color but REDIS?',
+                'url': 'redis:test',
+                'redis': True,
+                'redis_connection_params': {
+                    'host': 'local',
+                    'port': 6379
+                }
+            }
+        }
+    }
+    is_called = False
+    query_timeout = 2
+    # set
+    os.environ['REDIS_QUERY_TIMEOUT'] = str(query_timeout)
+    os.environ['BACKPLANE'] = 'http://localhost'
+    class graph_Inteface_mock:
+        def __init__(self, limit, skip, options_set):
+            self.limit = limit
+            self.skip = skip
+            self.options_set = options_set
+            self.answer_trapi_question
+            self.is_called = False
+
+        def get_schema(self, *args, **kwargs):
+            return {
+                "biolink:Gene": {"biolink:Gene": ['biolink:related_to']}
+            }
+
+        async def answer_trapi_question(self, message, options={}, timeout=None):
+            ### This is the actual test
+            assert timeout == query_timeout
+            self.is_called = True
+            # emppty result
+            return {}
+
+
+    gi_mock = graph_Inteface_mock(limit=20, skip=100, options_set=True)
+
+    with patch('PLATER.services.util.graph_adapter.GraphInterface.instance', gi_mock):
+        with patch('yaml.safe_load', lambda x: copy.deepcopy(mock_schema_yaml)):
+            # clean up schema singleton and setup tranql
+            update_interval = 1
+            backplane = 'http://localhost:8099'
+            schema_factory = SchemaFactory(
+                backplane=backplane,
+                use_registry=False,
+                update_interval=update_interval,
+                create_new=True,
+                tranql_config={}
+            )
+            tranql = TranQL()
+            tranql.schema = schema_factory.get_instance(force_update=True)
+
+            # Parse query
+
+            ast = tranql.parse(
+                """
+                SELECT g1:gene->g2:gene
+                FROM '/schema'
+                """
+            )
+            select_statement = ast.statements[0]
+
+            # execute query
+            select_statement.execute(interpreter=tranql)
+            # Check if gi_mock.answer is called
+            # note there is also an assert in that method to check if it's called with the right timeout from env
+            assert gi_mock.is_called

--- a/tranql/tranql_ast.py
+++ b/tranql/tranql_ast.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import json
 import logging
@@ -12,7 +13,6 @@ from tranql.concept import ConceptModel
 from tranql.concept import BiolinkModelWalker
 from tranql.util import Concept
 from tranql.util import JSONKit
-from tranql.util import light_merge
 from tranql.request_util import async_make_requests
 from tranql.util import Text, snake_case
 from tranql.exception import ServiceInvocationError
@@ -609,6 +609,37 @@ class SelectStatement(Statement):
                 break
         return schema
 
+    def query_redis (self, redis_connection_params, question, timeout=None):
+
+        if timeout:
+            try:
+                timeout = int(timeout)
+            except:
+                raise Exception('Configuration error: REDIS_QUERY_TIMEOUT needs to be integer.')
+        else:
+            timeout = 0
+
+        graph_interface: GraphInterface = GraphInterface(
+                **redis_connection_params
+            )
+        options = question.get('options')
+        limit = options.get('limit', [])
+        skip = options.get('skip', [])
+        max_connections = options.get('max_connectivity', [])
+        cypher_query_options = {}
+        if limit:
+            cypher_query_options['limit'] = limit[-1]
+        if skip:
+            cypher_query_options['skip'] = skip[-1]
+        if max_connections:
+            cypher_query_options['max_connectivity'] = max_connections[-1]
+        answer = asyncio.run(
+            graph_interface.answer_trapi_question(question['message']['query_graph'],
+                                                  options=cypher_query_options,
+                                                  timeout=timeout))
+        response = {'message': answer}
+        return response
+
     def execute (self, interpreter, context={}):
         """
         Execute all statements in the abstract syntax tree.
@@ -632,24 +663,21 @@ class SelectStatement(Statement):
                     'db_type': 'redis',
                 }
             )
-            graph_interface = GraphInterface(
-                **redis_connection_details
-            )
             question = self.generate_questions(interpreter)
-            import asyncio
-            options = question.get('options')
-            limit = options.get('limit', [])
-            skip = options.get('skip', [])
-            max_connections = options.get('max_connectivity', [])
-            cypher_query_options = {}
-            if limit:
-                cypher_query_options['limit'] = limit[-1]
-            if skip:
-                cypher_query_options['skip'] = skip[-1]
-            if max_connections:
-                cypher_query_options['max_connectivity'] = max_connections[-1]
-            answer = asyncio.run(graph_interface.answer_trapi_question(question['message']['query_graph'], options=cypher_query_options))
-            response = {'message': answer}
+            from redis.exceptions import ResponseError
+            timeout = interpreter.config.get('REDIS_QUERY_TIMEOUT')
+            try:
+                response = self.query_redis(redis_connection_params=redis_connection_details,
+                                            question=question,
+                                            timeout=timeout)
+            except ResponseError as e:
+                if str(e).lower() == 'query timed out':
+                    error = f"Running Query on redis timed out after {timeout} milliseconds. " \
+                            f"Hint: If query consists of multiple nodes try specifying edge types between the nodes. "
+                    interpreter.context.mem.get('requestErrors', []).extend(error)
+                else:
+                    error = f"Redis Error: `{e}`"
+                raise Exception(error)
             # Adds source db as reasoner attr in nodes and edges.
             self.decorate_result(response['message'], {
                 "schema": self.service
@@ -714,8 +742,7 @@ class SelectStatement(Statement):
 
             response['question_order'] = self.query.order
 
-            if len(response) == 0:
-                # @TODO might not be a proper error checking.
+            if not response.get('message'):
                 interpreter.context.mem.get('requestErrors',[]).append(ServiceInvocationError(
                     f"No valid results from {self.service} with query {self.query}"
                 ))
@@ -778,7 +805,13 @@ class SelectStatement(Statement):
                             details = Text.short (obj=f"{json.dumps(response, indent=2)}", limit=1000))
                     duplicate_statements = []
                     first_concept.set_curies(values)
+
+        # merge the responses from backend calls.
         merged = self.merge_results (responses)
+
+        # Although Merge above would merge question graphs , in cases where no results are returned
+        # we'd still want The root question here as the initial question
+        merged['message']['query_graph'] = root_question_graph
         return merged
 
     @staticmethod
@@ -1001,9 +1034,6 @@ class QueryPlanStrategy:
 
         for schema_name, sub_schema_package in self.schema.schema.items ():
             """ Look for a path satisfying this edge in each schema. """
-            # This will restrict usage of TRANQL with redis graph
-            # Explicitly i.e its either /schema or a redis backend
-            # @TODO handle this more elegantly
             sub_schema = sub_schema_package ['schema']
             sub_schema_url = sub_schema_package ['url']
 

--- a/tranql/tranql_ast.py
+++ b/tranql/tranql_ast.py
@@ -21,6 +21,8 @@ from tranql.exception import IllegalConceptIdentifierError
 from tranql.exception import UnknownServiceError
 from tranql.utils.merge_utils import merge_messages
 from PLATER.services.util.graph_adapter import GraphInterface
+from redis.exceptions import ResponseError as RedisResponseError
+
 
 logger = logging.getLogger (__name__)
 
@@ -664,13 +666,12 @@ class SelectStatement(Statement):
                 }
             )
             question = self.generate_questions(interpreter)
-            from redis.exceptions import ResponseError
             timeout = interpreter.config.get('REDIS_QUERY_TIMEOUT')
             try:
                 response = self.query_redis(redis_connection_params=redis_connection_details,
                                             question=question,
                                             timeout=timeout)
-            except ResponseError as e:
+            except RedisResponseError as e:
                 if str(e).lower() == 'query timed out':
                     error = f"Running Query on redis timed out after {timeout} milliseconds. " \
                             f"Hint: If query consists of multiple nodes try specifying edge types between the nodes. "

--- a/tranql/tranql_ast.py
+++ b/tranql/tranql_ast.py
@@ -624,7 +624,7 @@ class SelectStatement(Statement):
         graph_interface: GraphInterface = GraphInterface(
                 **redis_connection_params
             )
-        options = question.get('options')
+        options = question.get('options', {})
         limit = options.get('limit', [])
         skip = options.get('skip', [])
         max_connections = options.get('max_connectivity', [])


### PR DESCRIPTION
- Fixes "List out of Index" showing up when redis is empty and schema graph computed is also empty
```
SELECT a:gene->b:disease
FROM "/schema"
WHERE a="curie:ismissing"
```
Fix makes  behavior  return an empty response with the query graph evaluated from the query. 

- Adds timeouts to queries this is configurable as per deployment via 
"REDIS_QUERY_TIMEOUT" env variable. And value is in milliseconds. 

- Adds get parameter for /schema endpoint so we can do force refresh through an api call. Could be useful when roger pipeline finishes building graph we can let tranql recompute the schema. And don't need to wait till the next update interval.
