### PR TITLE
add heap size for build

### DIFF
--- a/src/tranql/web/package.json
+++ b/src/tranql/web/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts --max-old-space-size=4096 build",
     "test": "react-scripts test --transformIgnorePatterns \"/node_modules/(?!d3-force-graph)/\" --verbose true --testPathIgnorePatterns src/__tests__/mock",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
Docker builds are not able to finish due to node js server requiring more heap. 
(https://jenkins2.renci.org/job/helxplatform/job/tranql/view/tags/job/v0.4.dev0/1/console)