### PR TITLE
Fixes App.tranqlURL parsing on production env

### DIFF
--- a/src/tranql/web/src/App.js
+++ b/src/tranql/web/src/App.js
@@ -2658,7 +2658,10 @@ class App extends Component {
 
 if(process.env.NODE_ENV === 'production') {
   // behind proxy this would treat the path used to load index.html as root
-  App.prototype.tranqlURL = window.location.href.endsWith('/') ? window.location.href.substring(0, window.location.href.length - 1 ) : window.location.href.length ;
+  // Slice the query string off of the URL.
+  const fullURL = window.location.origin + window.location.pathname;
+  // Slice the hanging "/" off of the end of the URL if it is present.
+  App.prototype.tranqlURL = fullURL.endsWith("/") ? fullURL.slice(0, -1) : fullURL;
 } else {
   App.prototype.tranqlURL = "http://localhost:8001";
 }


### PR DESCRIPTION
The TranQL API URL will now be parsed as such:
- Take the web app's URL and cleave the query string.
- Take the new URL and cleave the hanging backslash at the end, if one is present.

Ex:
1. `https://heal-dev.apps.renci.org/tranql/?embed=FULL&q=SELECT%20gene-%3Edisease%0A%20%20FROM%20%22%2Fschema%22%0A%20WHERE%20limit%3D200` -> `https://heal-dev.apps.renci.org/tranql/`
2. `https://heal-dev.apps.renci.org/tranql/`-> `https://heal-dev.apps.renci.org/tranql`