### PR TITLE
Where statement autocomplete, TranQLIncompleteParser unit tests, and curie-to-English-name codemirror tooltips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ install: install.python install.npm
 #test.python: Run all python tests
 test.python:
 	#${PYTHON} -m pytest --doctest-modules src
-	${PYTHON} -m pytest tests
+	PYTHONPATH=${PWD}/src ${PYTHON} -m pytest tests
 
 #test.npm: Run all NPM tests
 test.npm:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "@codemirror/tooltip": "^0.19.6",
+    "@uiw/react-codemirror": "^4.2.3",
+    "codemirror": "^5.63.3"
+  }
+}

--- a/src/tranql/grammar.py
+++ b/src/tranql/grammar.py
@@ -146,7 +146,7 @@ incomplete_string = Group(delimitedList((Literal('"') | Literal("'")) + Regex('.
 
 incomplete_where_expression = Forward()
 incomplete_where_condition = Group(
-    ( columnName + binop + (quotedString.addParseAction(removeQuotes) | incomplete_string) ) |
+    ( columnName + binop + (quotedString | incomplete_string) ) |
     ( columnName + binop) |
     columnName |
     ( "(" + incomplete_where_expression + ")" )

--- a/src/tranql/web/src/App.js
+++ b/src/tranql/web/src/App.js
@@ -1723,9 +1723,7 @@ class App extends Component {
                     if (currentToken.type === "string" && currentToken.string.includes(":")) {
                       // It really doesn't need to be a curie here, since it'll just return no results,
                       // but might as well check if there's a colon to avoid making unnecessary API requests.
-                      try {
-                        this._resolveIdentifiersFromCurie(getCurieFromCMToken(currentToken.string));
-                      } catch {}
+                      this._resolveIdentifiersFromCurie(getCurieFromCMToken(currentToken.string)).catch(() => {})
                     }
                     if (this.embedded) this._debouncedExecuteQuery();
                   }}

--- a/src/tranql/web/src/App.js
+++ b/src/tranql/web/src/App.js
@@ -425,6 +425,9 @@ class App extends Component {
     // Fetch controllers
     this._queryController = new window.AbortController();
     this._autoCompleteController = new window.AbortController();
+    // This is a tracking symbol used to detect if a new autocomplete call has been opened.
+    // It it used to prevent stale autocompletion calls from writing to the codemirror state.
+    this._autoCompleteInstance = Symbol();
 
     this._OVERLAY_X = 0;
     this._OVERLAY_Y = 0;
@@ -1251,7 +1254,7 @@ class App extends Component {
   }
   _updateResolvedIdentifiers(results) {
     // Add results to the cache.
-    this._autocompleteResolvedIdentifiers = { ...this._autocompleteResolvedIdentifiers, ...results };
+    this._autocompleteResolvedIdentifiers = { ...results, ...this._autocompleteResolvedIdentifiers };
     // Update codemirror tooltips with new cached results.
     this._codemirror.state.resolvedIdentifiers = this._autocompleteResolvedIdentifiers;
   }

--- a/src/tranql/web/src/autocomplete.js
+++ b/src/tranql/web/src/autocomplete.js
@@ -581,7 +581,7 @@ export default function autoComplete () {
            try {
             const maxResults = 10;
             setLoading(true);
-            const possibleValuesFull = await this._resolveIdentifiersFromConcept(whereValue, whereConcept, 50);
+            const possibleValuesFull = await this._resolveIdentifiersFromConcept(whereValue, whereConcept, 250);
             setLoading(false);
             // resultLimit limits the number of results that can be returned by name resolution (typeless) but these results are then
             // culled by type-checking them, meaning there'll be much less than `resultLimit` results. Thus, we'll use a very high

--- a/src/tranql/web/src/autocomplete.js
+++ b/src/tranql/web/src/autocomplete.js
@@ -69,12 +69,12 @@ export default function autoComplete () {
              option.from = { line : from.line, ch : from.ch - replaceText.length };
              option.to = { line : to.line, ch : to.ch};
 
-             if (replaceText.length > 0) {
-               const trimmedLines = textToCursorPositionUntrimmed.trimRight().split(/\r\n|\r|\n/);
-               const lastLine = trimmedLines[trimmedLines.length-1];
-               option.from.line = trimmedLines.length - 1;
-               option.from.ch = lastLine.length - replaceText.length;
-             }
+            //  if (replaceText.length > 0) {
+            //    const trimmedLines = textToCursorPositionUntrimmed.trimRight().split(/\r\n|\r|\n/);
+            //    const lastLine = trimmedLines[trimmedLines.length-1];
+            //    option.from.line = trimmedLines.length - 1;
+            //    option.from.ch = lastLine.length - replaceText.length;
+            //  }
 
 
              delete option.replaceText;

--- a/src/tranql/web/src/autocomplete.js
+++ b/src/tranql/web/src/autocomplete.js
@@ -1,3 +1,8 @@
+import * as CodeMirror from 'codemirror';
+
+require('./codemirror-tooltip-extension/text-hover.js');
+require('./codemirror-tooltip-extension/text-hover.css');
+
 /**
 * Callback for handling autocompletion within the query editor.
 * 
@@ -576,9 +581,9 @@ export default function autoComplete () {
             // culled by type-checking them, meaning there'll be much less than `resultLimit` results. Thus, we'll use a very high
             // resultLimit to ensure an adequate number of type-checked results are returned and then only use the first few of them.
             const possibleValues = Object.fromEntries(Object.entries(possibleValuesFull).slice(0, maxResults));
-            const hints = Object.entries(possibleValues).map(([curie, labels]) => ({
-              displayText: labels.preferredLabel,
-              text: curie,
+            const hints = Object.entries(possibleValues).map(([curie, info]) => ({
+              displayText: info.preferredLabel,
+              text: info.preferredCurie,
               replaceText: whereValue
             }));
             setHint(hints);

--- a/src/tranql/web/src/autocomplete.js
+++ b/src/tranql/web/src/autocomplete.js
@@ -32,6 +32,8 @@ export default function autoComplete () {
  // // Adjust the position after trimming to be on the correct char.
  // pos.ch = splitLines[splitLines.length-1].length;
 
+ const isAutocompletionClosed = () => codeMirror.state.completionActive === null;
+
  const setHint = function(options, noResultsTip) {
    if (typeof noResultsTip === 'undefined') noResultsTip = true;
    if (noResultsTip && options.length === 0) {
@@ -457,13 +459,7 @@ export default function autoComplete () {
          }
          const endingQuote = currentReasonerArray[currentReasonerArray.length - 1][0];
          const currentReasoner = currentReasonerArray[currentReasonerArray.length - 1][1];
-         // The select statement must be the first statement in the block, but thorough just in case.
-         // We also want to filter out whitespace that would be detected as a token.
-         const selectStatement = block.filter((statement) => statement[0] === "select")[0].filter((token) => {
-           return typeof token !== "string" || token.match(/\s/) === null;
-         });
-         // Don't want the first token ("select")
-         const tokens = selectStatement.slice(1);
+         const tokens = parseTokensFromSelect(block);
 
          let validReasoners = [];
 
@@ -532,7 +528,66 @@ export default function autoComplete () {
          setHint(validReasonerValues);
        }
        else if (statementType === 'where') {
-
+         let whereBody = lastStatement[1];
+         // Just "WHERE" -> suggest concepts in the select statement
+         if (whereBody === undefined) {
+           whereBody = [""];
+         }
+         if (whereBody.length === 1) {
+          const [whereConcept] = whereBody;
+          const tokens = parseTokensFromSelect(block);
+          // Concepts (node selectors) are every 2n index, starting from n=0, i.e. 0, 2, 4, ...
+          // while edges are every 2n+1 index, i.e. 1, 3, 5, ...
+          // - For example, select disease->phenotypic feature would return tokens ['disease', '->', 'phenotypic_feature']
+          //   and return concepts ['disease', 'phenotypic_feature'].
+          // Then filter concepts to only those that start with the current text
+          const concepts = tokens.filter((token, i) => i % 2 === 0).filter((concept) => concept.startsWith(whereConcept));
+          const hints = concepts.map((concept) => ({
+            displayText: concept,
+            // text: concept + `="`,
+            text: concept,
+            replaceText: whereConcept
+          }));
+          setHint(hints);
+         }
+         else if (whereBody.length === 2 || whereBody.length === 3) {
+           let [ whereConcept, equals, whereValueFull ] = whereBody;
+           // If there is no value/open quotes, e.g. `disease=`, change it to `disease="`
+           if (whereValueFull === undefined) {
+             whereValueFull = [`"`, ""];
+           } else if (typeof whereValueFull === "string") {
+             // A completed where statement, with opening and closing quotes, e.g. `where disease="MONDO:XXX"`
+             return;
+           }
+           const [ openQuote, whereValue ] = whereValueFull;
+           // Get possible values for this concept.
+           // Note that a side-effect of this function is that it automatically stores the results within App state for autocomplete purposes.
+           // Also note that this function will always return empty when whereValue is an empty string (due to API limitations)
+           try {
+            const maxResults = 10;
+            setLoading(true);
+            const possibleValuesFull = await this._resolveIdentifiersFromConcept(whereValue, whereConcept, 50);
+            if (isAutocompletionClosed()) {
+              // If the autocompletion was closed while results were loading, then don't show the results.
+              return;
+            }
+            setLoading(false);
+            // resultLimit limits the number of results that can be returned by name resolution (typeless) but these results are then
+            // culled by type-checking them, meaning there'll be much less than `resultLimit` results. Thus, we'll use a very high
+            // resultLimit to ensure an adequate number of type-checked results are returned and then only use the first few of them.
+            const possibleValues = Object.fromEntries(Object.entries(possibleValuesFull).slice(0, maxResults));
+            const hints = Object.entries(possibleValues).map(([curie, labels]) => ({
+              displayText: labels.preferredLabel,
+              text: curie,
+              replaceText: whereValue
+            }));
+            setHint(hints);
+           } catch (e) {
+            // Handle fetch requests to the APIs failing.
+            setError('Error', 'API request failed', [{message: e.message, details: e.stack}]);
+           }
+           
+         }
        }
        }
        catch (e) {
@@ -545,4 +600,15 @@ export default function autoComplete () {
        setError('Error', 'Error', [{message: error.message, details: error.stack}]);
      }
    });
+}
+
+function parseTokensFromSelect(block) {
+  // The select statement must be the first statement in the block, but thorough just in case.
+  // We also want to filter out whitespace that would be detected as a token.
+  const selectStatement = block.filter((statement) => statement[0] === "select")[0].filter((token) => {
+    return typeof token !== "string" || token.match(/\s/) === null;
+  });
+  // Don't want the first token ("select")
+  const concepts = selectStatement.slice(1);
+  return concepts;
 }

--- a/src/tranql/web/src/codemirror-tooltip-extension/text-hover.css
+++ b/src/tranql/web/src/codemirror-tooltip-extension/text-hover.css
@@ -1,0 +1,24 @@
+.CodeMirror-hover-tooltip {
+	background-color: infobackground;
+	border: 1px solid black;
+	border-radius: 4px 4px 4px 4px;
+	color: infotext;
+	font-family: monospace;
+	font-size: 10pt;
+	overflow: hidden;
+	padding: 2px 5px;
+	position: fixed;
+	z-index: 100;
+	max-width: 600px;
+	opacity: 0;
+	white-space: pre-wrap;
+	transition: opacity .4s;
+	-moz-transition: opacity .4s;
+	-webkit-transition: opacity .4s;
+	-o-transition: opacity .4s;
+	-ms-transition: opacity .4s;
+}
+
+/*.CodeMirror-hover {
+	outline: 1px solid grey;
+}*/

--- a/src/tranql/web/src/codemirror-tooltip-extension/text-hover.js
+++ b/src/tranql/web/src/codemirror-tooltip-extension/text-hover.js
@@ -1,0 +1,194 @@
+import * as CodeMirror from 'codemirror';
+
+(function() {
+  "use strict";
+
+  var HOVER_CLASS = " CodeMirror-hover";
+
+  function showTooltip(e, content) {
+    var tt = document.createElement("div");
+    tt.className = "CodeMirror-hover-tooltip";
+    if (typeof content == "string") {
+      content = document.createTextNode(content);
+    }
+    if (content.innerText === "") tt.style.display = "none";
+    else tt.style.display = "block";
+    tt.appendChild(content);
+    document.body.appendChild(tt);
+
+    function position(e) {
+      if (!tt.parentNode)
+        return CodeMirror.off(document, "mousemove", position);
+      tt.style.top = Math.max(0, e.clientY - tt.offsetHeight - 5) + "px";
+      tt.style.left = (e.clientX + 5) + "px";
+    }
+    CodeMirror.on(document, "mousemove", position);
+    position(e);
+    if (tt.style.opacity != null)
+      tt.style.opacity = 1;
+    return tt;
+  }
+  function rm(elt) {
+    if (elt.parentNode)
+      elt.parentNode.removeChild(elt);
+  }
+  function hideTooltip(tt) {
+    if (!tt.parentNode)
+      return;
+    if (tt.style.opacity == null)
+      rm(tt);
+    tt.style.opacity = 0;
+    setTimeout(function() {
+      rm(tt);
+    }, 600);
+  }
+
+  function showTooltipFor(e, content, node, state, cm) {
+    var tooltip = showTooltip(e, content);
+    function hide() {
+      CodeMirror.off(node, "mouseout", hide);
+      CodeMirror.off(node, "click", hide);
+      node.className = node.className.replace(HOVER_CLASS, "");
+      if (tooltip) {
+        hideTooltip(tooltip);
+        tooltip = null;
+      }
+      cm.removeKeyMap(state.keyMap);
+    }
+    var poll = setInterval(function() {
+      if (tooltip)
+        for ( var n = node;; n = n.parentNode) {
+          if (n == document.body)
+            return;
+          if (!n) {
+            hide();
+            break;
+          }
+        }
+      if (!tooltip)
+        return clearInterval(poll);
+    }, 400);
+    CodeMirror.on(node, "mouseout", hide);
+    CodeMirror.on(node, "click", hide);
+    state.keyMap = {Esc: hide};
+    cm.addKeyMap(state.keyMap);
+  }
+
+  function TextHoverState(cm, options) {
+    this.options = options;
+    this.timeout = null;
+    if (options.delay) {
+      this.onMouseOver = function(e) {
+        onMouseOverWithDelay(cm, e);
+      };
+    } else {
+      this.onMouseOver = function(e) {
+        onMouseOver(cm, e);
+      };
+    }
+    this.keyMap = null;
+  }
+
+  function parseOptions(cm, options) {
+    if (options instanceof Function)
+      return {
+        getTextHover : options
+      };
+    if (!options || options === true)
+      options = {};
+    if (!options.getTextHover)
+      options.getTextHover = function(cm, data, node) {
+        var html = null;
+        if (data) {
+          var {string, type, start, end } = data.token;
+          if (type === "string") {
+            // Cut the starting and ending quotation marks/apostrophes out of the value.
+            let value = string.slice(1);
+            // A string may not necessarily be closed yet, so only remove the last character if it is, in fact, closed.
+            if (value.endsWith(`"`) || value.endsWith(`'`)) value = value.slice(0, -1);
+            // Check if the value is a curie that is cached.
+            if (cm.state.resolvedIdentifiers && cm.state.resolvedIdentifiers[value]) {
+              console.log(cm.state.resolvedIdentifiers[value]);
+              html = cm.state.resolvedIdentifiers[value].preferredLabel;
+            }
+          }
+        }
+        var result = document.createElement('div');
+        if (html !== null) {
+          result.innerHTML = html;
+        }
+        return result;
+      }
+    if (!options.getTextHover)
+      throw new Error(
+          "Required option 'getTextHover' missing (text-hover addon)");
+    return options;
+  }
+
+  function onMouseOverWithDelay(cm, e) {
+    var state = cm.state.textHover, delay = state.options.delay;
+    clearTimeout(state.timeout);
+    if (e.srcElement) {
+    	// hack for IE, because e.srcElement failed when it is used in the tiemout function
+    	var newE = {srcElement: e.srcElement, clientX : e.clientX, clientY: e.clientY};
+    	e = newE;
+    }
+    state.timeout = setTimeout(function() {onMouseOver(cm, e);}, delay);
+  }
+
+  function onMouseOver(cm, e) {
+    var node = e.target || e.srcElement;
+    if (node) {
+      if (/\bCodeMirror-lint-mark-/.test(node.className)) return; // hack if lint addon is used to give it a higher priority
+      var state = cm.state.textHover, data = getTokenAndPosAt(cm, e);
+      var content = state.options.getTextHover(cm, data, e);
+      if (content) {
+        node.className += HOVER_CLASS;
+        if (typeof content == 'function') 
+	      content(showTooltipFor, data, e, node, state, cm);
+        else 
+          showTooltipFor(e, content, node, state, cm);        
+      }
+    }
+  }
+
+  function optionHandler(cm, val, old) {
+    if (old && old != CodeMirror.Init) {
+      CodeMirror.off(cm.getWrapperElement(), "mouseover",
+          cm.state.textHover.onMouseOver);
+      delete cm.state.textHover;
+    }
+
+    if (val) {
+      var state = cm.state.textHover = new TextHoverState(cm, parseOptions(cm,
+          val));
+      CodeMirror.on(cm.getWrapperElement(), "mouseover", state.onMouseOver);
+    }
+  }
+
+  // When the mouseover fires, the cursor might not actually be over
+  // the character itself yet. These pairs of x,y offsets are used to
+  // probe a few nearby points when no suitable marked range is found.
+  var nearby = [ 0, 0, 0, 5, 0, -5, 5, 0, -5, 0 ];
+
+  function getTokenAndPosAt(cm, e) {
+    var node = e.target || e.srcElement, text = node.innerText
+        || node.textContent;
+    for ( var i = 0; i < nearby.length; i += 2) {
+      var pos = cm.coordsChar({
+        left : e.clientX + nearby[i],
+        top : e.clientY + nearby[i + 1]
+      });
+      var token = cm.getTokenAt(pos);
+      if (token && token.string === text) {
+        return {
+          token : token,
+          pos : pos
+        };
+      }
+    }
+  }
+
+  CodeMirror.defineOption("textHover", false, optionHandler); // deprecated
+
+})();

--- a/src/tranql/web/src/codemirror-tooltip-extension/text-hover.js
+++ b/src/tranql/web/src/codemirror-tooltip-extension/text-hover.js
@@ -1,5 +1,13 @@
 import * as CodeMirror from 'codemirror';
 
+export function getCurieFromCMToken(string) {
+   // Cut the starting and ending quotation marks/apostrophes out of the value.
+   let value = string.slice(1);
+   // A string may not necessarily be closed yet, so only remove the last character if it is, in fact, closed.
+   if (value.endsWith(`"`) || value.endsWith(`'`)) value = value.slice(0, -1);
+   return value;
+}
+
 (function() {
   "use strict";
 
@@ -102,11 +110,8 @@ import * as CodeMirror from 'codemirror';
         if (data) {
           var {string, type, start, end } = data.token;
           if (type === "string") {
-            // Cut the starting and ending quotation marks/apostrophes out of the value.
-            let value = string.slice(1);
-            // A string may not necessarily be closed yet, so only remove the last character if it is, in fact, closed.
-            if (value.endsWith(`"`) || value.endsWith(`'`)) value = value.slice(0, -1);
-            // Check if the value is a curie that is cached.
+           const value = getCurieFromCMToken(string);
+            // Check if the value is a curie that is cached. If so, add a tooltip with the curie's English label.
             if (cm.state.resolvedIdentifiers && cm.state.resolvedIdentifiers[value]) {
               console.log(cm.state.resolvedIdentifiers[value]);
               html = cm.state.resolvedIdentifiers[value].preferredLabel;

--- a/src/tranql/web/src/codemirror-tooltip-extension/text-hover.js
+++ b/src/tranql/web/src/codemirror-tooltip-extension/text-hover.js
@@ -113,7 +113,6 @@ export function getCurieFromCMToken(string) {
            const value = getCurieFromCMToken(string);
             // Check if the value is a curie that is cached. If so, add a tooltip with the curie's English label.
             if (cm.state.resolvedIdentifiers && cm.state.resolvedIdentifiers[value]) {
-              console.log(cm.state.resolvedIdentifiers[value]);
               html = cm.state.resolvedIdentifiers[value].preferredLabel;
             }
           }

--- a/tests/test_tranql.py
+++ b/tests/test_tranql.py
@@ -326,44 +326,173 @@ def test_parse_query_with_repeated_concept (GraphInterfaceMock, requests_mock):
 ######################################################################################
 # TranQLIncompleteParser tests. For /tranql/parse_incomplete autocompletion endpoint #
 ######################################################################################
-def test_parse_incomplete_where_clause(requests_mock):
-    program = """
-select gene->disease
-  from "/schema"
- where disease="asth
-    """
+
+"""
+Helper function used by tests for TranQLIncompleteParser to cut down on the boilerplate required in each test scenario.
+"""
+def _test_parse_incomplete(program, expected):
     parser = TranQLIncompleteParser (None)
     parsed = parser.tokenize(program)
     result = parsed.asList()
-    expected = [
-        [
+    assert_lists_equal(result, expected)
+
+#######################
+# Select clause tests #
+#######################
+def test_parse_incomplete_select_clause():
+    _test_parse_incomplete(
+        """select gene-[affects_expression_of]->protein->disease<-[treats]-phenotypic_feature""",
+        [[
             [
                 "select",
                 "gene",
+                ["-[", "affects_expression_of", "]->"],
+                "protein",
                 "->",
                 "disease",
-                "\n"
-            ],
-            [
-                "from",
-                [
-                    ["/schema"]
-                ]
-            ],
-            [
-                "where",
-                [
-                    "disease",
-                    "=",
-                    [
-                        '"',
-                        "asth"
-                    ]
-                ]
+                ["<-[", "treats", "]-"],
+                "phenotypic_feature"
             ]
-        ]
-    ]
-    assert_lists_equal(result, expected)
+        ]]
+    )
+    _test_parse_incomplete(
+        """select gene-""",
+        [[
+            [
+                "select",
+                "gene",
+                "-"
+            ]
+        ]]
+    )
+    _test_parse_incomplete(
+        """select gene-[""",
+        [[
+            [
+                "select",
+                "gene",
+                ["-["]
+            ]
+        ]]
+    )
+    _test_parse_incomplete(
+        """select gene-[affects""",
+        [[
+            [
+                "select",
+                "gene",
+                ["-[", "affects"]
+            ]
+        ]]
+    )
+    _test_parse_incomplete(
+        """select """,
+        [[
+            [
+                "select",
+            ]
+        ]]
+    )
+
+#####################
+# From clause tests #
+#####################
+def test_parse_incomplete_from_clause():
+    _test_parse_incomplete(
+        """
+        select gene->disease
+         from "/schema"
+        """,
+        [[
+            ["select", "gene", "->", "disease", "\n"],
+            ["from", [["/schema"]]]
+        ]]
+    )
+    _test_parse_incomplete(
+        """
+        select gene->disease
+         from "/schema
+        """,
+        [[
+            ["select", "gene", "->", "disease", "\n"],
+            ["from", [['"', "/schema"]]]
+        ]]
+    )
+    _test_parse_incomplete(
+        """
+        select gene->disease
+         from
+        """,
+        [[
+            ["select", "gene", "->", "disease", "\n"],
+            ["from"]
+        ]]
+    )
+
+######################
+# Where clause tests #
+######################
+def test_parse_incomplete_where_clause():
+    _test_parse_incomplete(
+        """
+        select gene->disease
+          from "/schema"
+         where disease="asth"
+        """,
+        [[
+            ["select", "gene", "->", "disease", "\n"],
+            ["from", [["/schema"]]],
+            ["where", ["disease", "=", "asth"]]
+        ]]   
+    )
+    _test_parse_incomplete(
+        """
+        select gene->disease
+          from "/schema"
+         where disease="asth
+        """,
+        [[
+            ["select", "gene", "->", "disease", "\n"],
+            ["from", [["/schema"]]],
+            ["where", ["disease", "=", ['"', "asth"]]]
+        ]]   
+    )
+    _test_parse_incomplete(
+        """
+        select gene->disease
+          from "/schema"
+         where disease=
+        """,
+        [[
+            ["select", "gene", "->", "disease", "\n"],
+            ["from", [["/schema"]]],
+            ["where", ["disease", "="]]
+        ]]   
+    )
+    _test_parse_incomplete(
+        """
+        select gene->disease
+          from "/schema"
+         where disease
+        """,
+        [[
+            ["select", "gene", "->", "disease", "\n"],
+            ["from", [["/schema"]]],
+            ["where", ["disease"]]
+        ]]   
+    )
+    _test_parse_incomplete(
+        """
+        select gene->disease
+          from "/schema"
+         where 
+        """,
+        [[
+            ["select", "gene", "->", "disease", "\n"],
+            ["from", [["/schema"]]],
+            ["where"]
+        ]]   
+    )
 
 #####################################################
 #

--- a/tests/test_tranql.py
+++ b/tests/test_tranql.py
@@ -11,7 +11,7 @@ import yaml
 from tests.mocks import MockHelper
 from tests.mocks import MockMap
 from tests.util import assert_lists_equal, set_mock, ordered
-from tranql.main import TranQL
+from tranql.main import TranQL, TranQLIncompleteParser
 from tranql.tranql_ast import SetStatement, SelectStatement, custom_functions
 from tranql.tranql_schema import SchemaFactory
 from tranql.utils.merge_utils import connect_knowledge_maps, find_all_paths
@@ -322,6 +322,48 @@ def test_parse_query_with_repeated_concept (GraphInterfaceMock, requests_mock):
               ["$.knowledge_graph.nodes.[*].id","as","diagnoses"]
              ]
             ]])
+
+######################################################################################
+# TranQLIncompleteParser tests. For /tranql/parse_incomplete autocompletion endpoint #
+######################################################################################
+def test_parse_incomplete_where_clause(requests_mock):
+    program = """
+select gene->disease
+  from "/schema"
+ where disease="asth
+    """
+    parser = TranQLIncompleteParser (None)
+    parsed = parser.tokenize(program)
+    result = parsed.asList()
+    expected = [
+        [
+            [
+                "select",
+                "gene",
+                "->",
+                "disease",
+                "\n"
+            ],
+            [
+                "from",
+                [
+                    ["/schema"]
+                ]
+            ],
+            [
+                "where",
+                [
+                    "disease",
+                    "=",
+                    [
+                        '"',
+                        "asth"
+                    ]
+                ]
+            ]
+        ]
+    ]
+    assert_lists_equal(result, expected)
 
 #####################################################
 #


### PR DESCRIPTION
## Incomplete where clause parsing
This PR chiefly adds support for parsing incomplete where statements into the grammar used by `TranQLIncompleteParser`.
- It adds support into the client-side autocompletion for intelligent where statement completion.
  - Typing English strings into a where statement value will suggest English names returned by `https://name-resolution-sri.renci.org/lookup`. These suggestions are context aware, that is, only things of the same type as the where clause concept will be used (i.e. `WHERE disease="water` will return `water intoxication` (disease) but not `water` (chemical_substance).
  - The autocompletion also queries node-normalization to resolve the types of each concept returned by name-resolutions (for the above-mentioned context-awareness) and to get its preferred English "label" to display for the curie as well as its preferred curie to fill in the value.
  - Choosing an autocompletion option will fill in node-norm's preferred curie for the identifier rather than the English value.

> Note: it currently parses every where clause value as a string. This could be extended to support any type available in a usual where statement, like numbers, lists, and functions, but this didn't seem very important right now.

## Curie to English name tooltips
This also adds a feature so that the app automatically looks up curies typed into the codemirror and displays their English name when hovering over them.
- This functionality is available upon page load and will work on all curies, not just the ones filled in with autocompletion.
- This similarly queries node-normalization to get its preferred English label for a curie to display.

Additionally, this changes the language used by codemirror for highlighting from `x-pgsql` (postgres) to `x-mysql` (mysql).
- The highlighting is identical for the most part (it doesn't actively remove/change any highlighting).
- However, it fixes the highlighting behavior for strings enclosed in quotation marks, whereas previously, highlighting only worked on apostrophe-enclosed strings (this is an oddity of how Postgres differentiates between these things and only treats apostrophe strings as actual strings).
- This change was necessary for parsing curies from the codemirror query easily, since both types of strings will be tokenized just as "strings" by the codemirror parser.

## Unit tests
This PR adds a lot of unit tests for the incomplete grammar parsing, since none existed beforehand.

It also updates `make test.python` in the Makefile to run tests using the tranql in `src/tranql` rather than the pip package that is locally installed (`pip install .`) when running `make install.python`.
