### PR TITLE
use latest plater with connection fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ redisgraph==2.2.4
 requests==2.25.1
 requests-cache==0.4.13
 requests-mock==1.5.2
-git+https://github.com/helxplatform/Plater.git@v1.9.9
+git+https://github.com/helxplatform/Plater.git@v2.0.0
 bmt==0.7.2
 git+https://github.com/ranking-agent/reasoner.git
 git+https://github.com/TranslatorSRI/reasoner-pydantic@v1.0.0#egg=reasoner-pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ coverage==4.5.3
 flasgger==0.9.2
 flask==1.0.2
 flask-cors==3.0.7
-# flask-restful==0.3.7
 flask-restx==0.5.1
 gunicorn==19.9.0
 jinja2==2.10
@@ -15,7 +14,6 @@ pytest-cov==2.7.1
 python-coveralls==2.9.2
 python-dateutil==2.8.1
 pyyaml==5.1
-redisgraph==2.2.4
 requests==2.25.1
 requests-cache==0.4.13
 requests-mock==1.5.2


### PR DESCRIPTION
- Latest plater now uses redis lib 4.1.2. 
Redis graph py is being deprecated as [graph features](https://github.com/redis/redis-py/tree/master/redis/commands/graph) have been added to the redis lib. so we will no longer need that here.
- Plater now runs health check on connection every two seconds. And connection will be retried 3 times with no backoff [here are the changes ](https://github.com/helxplatform/Plater/blob/a2e1dd97e2b50b388b3c108df21110ef5393dd94/PLATER/services/util/drivers/redis_driver.py#L21) 