### PR TITLE
Bmt version fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,9 @@ requests-cache==0.4.13
 requests-mock==1.5.2
 git+https://github.com/helxplatform/Plater.git@v2.0.0
 bmt==0.8.2
+linkml==1.1.17
+linkml-dataops==0.1.0
+linkml-runtime==1.1.21
 reasoner-transpiler==1.7.1
 git+https://github.com/TranslatorSRI/reasoner-pydantic@v1.0.0#egg=reasoner-pydantic
 git+https://github.com/TranslatorSRI/reasoner-converter@1.2.4#egg=reasoner-converter


### PR DESCRIPTION
- Linkml dependency was giving errors on server startup. Bmt v 0.7.* didn't have pinned dependecy to it so we were getting errors. 
